### PR TITLE
Update cron triggers to match new Cloudflare format

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ export async function onRequestGet(c) {
 
 The [scheduled.js](functions/scheduled.js) file will run every minute by default (after your first deployment).
 
-To disable scheduling, delete the scheduled.js file and remove the triggers from wrangler.jsonc.
+To disable scheduling, delete the scheduled.js file and remove the triggers from wrangler.json.
 
 NOTE: There are some small gotchas here:
 

--- a/wrangler.json
+++ b/wrangler.json
@@ -11,6 +11,11 @@
   "vars": {
     "ENV": "dev"
   },
+  "triggers": {
+    "crons": [
+      "* * * * *"
+    ]
+  },
   "kv_namespaces": [
     {
       "binding": "KV",


### PR DESCRIPTION
Updates cron triggers configuration in `wrangler.json` to the new format (`triggers.crons`) as specified in [Cloudflare Cron Triggers documentation](https://developers.cloudflare.com/workers/configuration/cron-triggers/).