### PR TITLE
feat: avatar menu and settings page with R2 uploads, name editing, and passkeys

### DIFF
--- a/functions/_middleware.js
+++ b/functions/_middleware.js
@@ -17,8 +17,28 @@ export async function wrap(c) {
     const sess = await getSession({ request: c.request, kv: c.env.KV })
     if (sess && sess.userId) {
       let user = await c.data.d1.get(User, sess.userId)
+      let kvUser = null
+      if (!user || !user.email) {
+        try {
+          const rawKvUser = await c.env.KV.get(`users-${sess.userId}`)
+          if (rawKvUser) {
+            kvUser = JSON.parse(rawKvUser)
+          }
+        } catch (e) {}
+      }
+
+      const email = user?.email || sess.email || kvUser?.email || (sess.userId.includes('@') ? sess.userId : null)
+
       if (!user) {
-        user = { id: sess.userId, email: sess.email }
+        user = { id: sess.userId, email }
+        try {
+          await c.data.d1.insert(User, user)
+        } catch (e) {}
+      } else if (!user.email && email) {
+        user.email = email
+        try {
+          await c.data.d1.update(User, user.id, { email })
+        } catch (e) {}
       }
       c.data.user = user
     }

--- a/functions/auth/[[catchall]].js
+++ b/functions/auth/[[catchall]].js
@@ -125,14 +125,19 @@ export async function onRequest(c) {
         return Response.json({ error: { message: 'Passkey ID is required' } }, { status: 400 })
       }
 
-      await c.env.KV.delete(`passkeys-${passkeyId}`)
-
       let userRaw = await c.env.KV.get(`users-${sess.id}`)
-      if (userRaw) {
-        let userObj = JSON.parse(userRaw)
-        userObj.passkeys = (userObj.passkeys || []).filter((pk) => pk.id !== passkeyId)
-        await c.env.KV.put(`users-${sess.id}`, JSON.stringify(userObj))
+      if (!userRaw) {
+        return Response.json({ error: { message: 'User not found' } }, { status: 404 })
       }
+      let userObj = JSON.parse(userRaw)
+      let existingList = userObj.passkeys || []
+      if (!existingList.some((pk) => pk.id === passkeyId)) {
+        return Response.json({ error: { message: 'Passkey not found for user' } }, { status: 404 })
+      }
+
+      await c.env.KV.delete(`passkeys-${passkeyId}`)
+      userObj.passkeys = existingList.filter((pk) => pk.id !== passkeyId)
+      await c.env.KV.put(`users-${sess.id}`, JSON.stringify(userObj))
       return Response.json({ success: true, message: 'Passkey deleted' })
     }
   }

--- a/functions/auth/[[catchall]].js
+++ b/functions/auth/[[catchall]].js
@@ -2,6 +2,7 @@ import { Passkeys } from 'passkeys'
 import { hostURL } from '../utils.js'
 import { globals } from '../globals.js'
 import { isoBase64URL } from '@simplewebauthn/server/helpers'
+import { User } from '../data/users.js'
 
 export async function onRequest(c) {
   let p = c.params.catchall
@@ -12,6 +13,17 @@ export async function onRequest(c) {
     kv: c.env.KV,
     // mailer: globals.mailer, // replace with your own mailer instance with send() function
     logger: c.data.logger,
+    emailStart: async ({ email }) => {
+      let normalized = (email || '').toLowerCase().trim()
+      let user = await c.data.d1.first(User, { where: { email: normalized } })
+      if (!user) {
+        user = await c.data.d1.insert(User, {
+          email: normalized,
+          name: normalized.split('@')[0],
+        })
+      }
+      return { userId: user.id }
+    },
   })
 
   if (p[0] == 'email') {

--- a/functions/auth/[[catchall]].js
+++ b/functions/auth/[[catchall]].js
@@ -1,12 +1,13 @@
 import { Passkeys } from 'passkeys'
 import { hostURL } from '../utils.js'
 import { globals } from '../globals.js'
+import { isoBase64URL } from '@simplewebauthn/server/helpers'
 
 export async function onRequest(c) {
   let p = c.params.catchall
   console.log('CATCHALL', p)
   let passkeys = new Passkeys({
-    appName: 'Passkeys demo',
+    appName: 'Flaregun',
     baseURL: `${hostURL(c)}/auth`,
     kv: c.env.KV,
     // mailer: globals.mailer, // replace with your own mailer instance with send() function
@@ -28,13 +29,99 @@ export async function onRequest(c) {
       return await passkeys.start(c)
     }
     if (p[1] == 'create') {
-      return await passkeys.create(c)
+      let reqClone = c.request.clone()
+      let input = {}
+      try {
+        input = await reqClone.json()
+      } catch (e) {}
+
+      let res = await passkeys.create(c)
+
+      let userId = c.data.user?.id
+      if (!userId && input.userId) {
+        try {
+          userId = isoBase64URL.toUTF8String(input.userId)
+        } catch (e) {}
+      }
+
+      if (res.status === 200 || res.ok) {
+        let passkeyId = input.credential?.id
+        if (passkeyId && userId) {
+          let passkeyRaw = await c.env.KV.get(`passkeys-${passkeyId}`)
+          if (passkeyRaw) {
+            let passkeyObj = JSON.parse(passkeyRaw)
+            passkeyObj.createdAt = new Date().toISOString()
+            passkeyObj.name = input.name || (passkeyObj.deviceType === 'multiDevice' ? 'Passkey' : 'Security Key')
+            await c.env.KV.put(`passkeys-${passkeyId}`, JSON.stringify(passkeyObj))
+
+            let userRaw = await c.env.KV.get(`users-${userId}`)
+            let userObj = userRaw ? JSON.parse(userRaw) : { id: userId, passkeys: [] }
+            let existingList = userObj.passkeys || []
+            if (!existingList.some((pk) => pk.id === passkeyId)) {
+              existingList.push(passkeyObj)
+            } else {
+              existingList = existingList.map((pk) => (pk.id === passkeyId ? passkeyObj : pk))
+            }
+            userObj.passkeys = existingList
+            await c.env.KV.put(`users-${userId}`, JSON.stringify(userObj))
+          }
+        }
+      }
+      return res
     }
     if (p[1] == 'verify') {
       return await passkeys.verify(c)
     }
     if (p[1] == 'check') {
       return await passkeys.check(c)
+    }
+    if (p[1] == 'list') {
+      let sess = c.data.user
+      if (!sess || !sess.id) {
+        return Response.json({ error: { message: 'Unauthorized' } }, { status: 401 })
+      }
+      let userRaw = await c.env.KV.get(`users-${sess.id}`)
+      let passkeysList = []
+      if (userRaw) {
+        let parsed = JSON.parse(userRaw)
+        passkeysList = parsed.passkeys || []
+      }
+      return Response.json({
+        passkeys: passkeysList.map((pk) => ({
+          id: pk.id,
+          name: pk.name || (pk.deviceType === 'multiDevice' ? 'Passkey' : 'Security Key'),
+          deviceType: pk.deviceType,
+          backedUp: pk.backedUp,
+          createdAt: pk.createdAt || null,
+          transports: pk.transports || [],
+        })),
+      })
+    }
+    if (p[1] == 'delete' || p[1] == 'remove') {
+      let sess = c.data.user
+      if (!sess || !sess.id) {
+        return Response.json({ error: { message: 'Unauthorized' } }, { status: 401 })
+      }
+      let passkeyId = p[2]
+      if (!passkeyId) {
+        try {
+          let body = await c.request.json()
+          passkeyId = body.id
+        } catch (e) {}
+      }
+      if (!passkeyId) {
+        return Response.json({ error: { message: 'Passkey ID is required' } }, { status: 400 })
+      }
+
+      await c.env.KV.delete(`passkeys-${passkeyId}`)
+
+      let userRaw = await c.env.KV.get(`users-${sess.id}`)
+      if (userRaw) {
+        let userObj = JSON.parse(userRaw)
+        userObj.passkeys = (userObj.passkeys || []).filter((pk) => pk.id !== passkeyId)
+        await c.env.KV.put(`users-${sess.id}`, JSON.stringify(userObj))
+      }
+      return Response.json({ success: true, message: 'Passkey deleted' })
     }
   }
   return Response.json({})

--- a/functions/data/users.js
+++ b/functions/data/users.js
@@ -21,6 +21,9 @@ export class User {
     age: {
       type: Number,
     },
+    image: {
+      type: String,
+    },
     data: {
       type: Object,
     },

--- a/functions/layout.js
+++ b/functions/layout.js
@@ -48,6 +48,7 @@ export async function layout(d) {
       <body>
         <script type="module">
           import 'passkeys/public/components/sign-in-button.js'
+          import '/components/avatar-menu.js'
         </script>
         <div class="flex g12 jcsb mb20 topnav">
           <a href="/">
@@ -58,7 +59,11 @@ export async function layout(d) {
           </a>
           <div class="flex g8 jcc aic">
             <div>
-              <sign-in-button href="/signin">Sign In</sign-in-button>
+              ${
+                d.user
+                  ? html`<avatar-menu user="${JSON.stringify(d.user)}"></avatar-menu>`
+                  : html`<sign-in-button href="/signin">Sign In</sign-in-button>`
+              }
             </div>
           </div>
         </div>

--- a/functions/layout.js
+++ b/functions/layout.js
@@ -61,7 +61,7 @@ export async function layout(d) {
             <div>
               ${
                 d.user
-                  ? html`<avatar-menu user="${JSON.stringify(d.user)}"></avatar-menu>`
+                  ? html`<avatar-menu user="${JSON.stringify(d.user).replace(/"/g, '&quot;')}"></avatar-menu>`
                   : html`<sign-in-button href="/signin">Sign In</sign-in-button>`
               }
             </div>

--- a/functions/layout.js
+++ b/functions/layout.js
@@ -40,7 +40,7 @@ export async function layout(d) {
               "api": "https://cdn.jsdelivr.net/gh/treeder/api@1/api.js",
               "state": "https://cdn.jsdelivr.net/gh/treeder/state@3/state.js",
               "models": "https://cdn.jsdelivr.net/gh/treeder/models@1/index.js",
-              "passkeys/": "https://cdn.jsdelivr.net/gh/treeder/passkeys@4/"
+              "passkeys/": "https://cdn.jsdelivr.net/gh/treeder/passkeys@5/"
             }
           }
         </script>

--- a/functions/r2/[[key]].js
+++ b/functions/r2/[[key]].js
@@ -16,6 +16,9 @@ export async function onRequestGet(c) {
   if (!file) throw new APIError('file not found', { status: 404 })
   const headers = new Headers()
   headers.append('etag', file.httpEtag)
+  if (file.httpMetadata?.contentType) {
+    headers.set('content-type', file.httpMetadata.contentType)
+  }
   return new Response(file.body, {
     headers,
   })

--- a/functions/settings.js
+++ b/functions/settings.js
@@ -23,7 +23,7 @@ function render(d) {
     </script>
 
     <div class="flex col aic jcc p16 mt20">
-      <settings-page user="${JSON.stringify(d.user)}"></settings-page>
+      <settings-page user="${JSON.stringify(d.user).replace(/"/g, '&quot;')}"></settings-page>
     </div>
   `
 }

--- a/functions/settings.js
+++ b/functions/settings.js
@@ -1,0 +1,29 @@
+import { html } from 'rend'
+
+export async function onRequestGet(c) {
+  if (!c.data.user) {
+    return new Response(null, {
+      status: 302,
+      headers: {
+        Location: '/signin?redirect=/settings',
+      },
+    })
+  }
+
+  return await c.data.rend.html({
+    title: 'Settings',
+    main: render,
+  })
+}
+
+function render(d) {
+  return html`
+    <script type="module">
+      import '/components/settings-page.js'
+    </script>
+
+    <div class="flex col aic jcc p16 mt20">
+      <settings-page user="${JSON.stringify(d.user)}"></settings-page>
+    </div>
+  `
+}

--- a/functions/signout.js
+++ b/functions/signout.js
@@ -1,0 +1,11 @@
+export async function onRequestGet(c) {
+  const headers = new Headers({
+    Location: '/',
+  })
+  headers.append('Set-Cookie', 'session=; expires=Thu, 01 Jan 1970 00:00:01 UTC; Path=/;')
+  headers.append('Set-Cookie', 'userId=; expires=Thu, 01 Jan 1970 00:00:01 UTC; Path=/;')
+  return new Response(null, {
+    status: 302,
+    headers,
+  })
+}

--- a/functions/v1/users/avatar/index.js
+++ b/functions/v1/users/avatar/index.js
@@ -33,6 +33,7 @@ export async function onRequestPost(c) {
   let ext = 'jpg'
   if (file.type === 'image/png') ext = 'png'
   else if (file.type === 'image/webp') ext = 'webp'
+  else if (file.type === 'image/avif') ext = 'avif'
   else if (file.type === 'image/gif') ext = 'gif'
   else if (file.type === 'image/svg+xml') ext = 'svg'
   else {

--- a/functions/v1/users/avatar/index.js
+++ b/functions/v1/users/avatar/index.js
@@ -42,7 +42,7 @@ export async function onRequestPost(c) {
     }
   }
 
-  const filename = `${nanoid()}.${ext}`
+  const filename = `avatar-${nanoid()}.${ext}`
   const key = `users/${c.data.user.id}/${filename}`
 
   await c.env.R2.put(key, buffer, {

--- a/functions/v1/users/avatar/index.js
+++ b/functions/v1/users/avatar/index.js
@@ -1,0 +1,82 @@
+import { APIError } from 'api'
+import { nanoid } from 'nanoid'
+import { User } from '../../../data/users.js'
+
+export async function onRequestPost(c) {
+  if (!c.data.user) {
+    throw new APIError('Unauthorized', { status: 401 })
+  }
+
+  let formData
+  try {
+    formData = await c.request.formData()
+  } catch (err) {
+    throw new APIError('Invalid form data', { status: 400 })
+  }
+
+  const file = formData.get('file') || formData.get('avatar') || formData.get('image')
+  if (!file || typeof file === 'string') {
+    throw new APIError('File is required', { status: 400 })
+  }
+
+  if (!file.type || !file.type.startsWith('image/')) {
+    throw new APIError('Only image files are allowed', { status: 400 })
+  }
+
+  const maxBytes = 10 * 1024 * 1024 // 10MB
+  if (file.size && file.size > maxBytes) {
+    throw new APIError('File size exceeds 10MB limit', { status: 400 })
+  }
+
+  const buffer = await file.arrayBuffer()
+
+  let ext = 'jpg'
+  if (file.type === 'image/png') ext = 'png'
+  else if (file.type === 'image/webp') ext = 'webp'
+  else if (file.type === 'image/gif') ext = 'gif'
+  else if (file.type === 'image/svg+xml') ext = 'svg'
+  else {
+    const parts = (file.name || '').split('.')
+    if (parts.length > 1) {
+      ext = parts.pop().toLowerCase()
+    }
+  }
+
+  const filename = `${nanoid()}.${ext}`
+  const key = `users/${c.data.user.id}/${filename}`
+
+  await c.env.R2.put(key, buffer, {
+    httpMetadata: {
+      contentType: file.type || 'image/jpeg',
+    },
+  })
+
+  const image = `/r2/${key}`
+  const existing = await c.data.d1.get(User, c.data.user.id)
+  if (!existing) {
+    await c.data.d1.insert(User, {
+      id: c.data.user.id,
+      email: c.data.user.email,
+      image,
+    })
+  } else {
+    await c.data.d1.update(User, c.data.user.id, { image })
+  }
+
+  const updated = await c.data.d1.get(User, c.data.user.id)
+  return Response.json({ success: true, image, user: updated })
+}
+
+export async function onRequestDelete(c) {
+  if (!c.data.user) {
+    throw new APIError('Unauthorized', { status: 401 })
+  }
+
+  const existing = await c.data.d1.get(User, c.data.user.id)
+  if (existing) {
+    await c.data.d1.update(User, c.data.user.id, { image: null })
+  }
+
+  const updated = await c.data.d1.get(User, c.data.user.id)
+  return Response.json({ success: true, user: updated })
+}

--- a/functions/v1/users/me/index.js
+++ b/functions/v1/users/me/index.js
@@ -1,0 +1,43 @@
+import { APIError } from 'api'
+import { User } from '../../../data/users.js'
+
+export async function onRequestGet(c) {
+  if (!c.data.user) throw new APIError('Unauthorized', { status: 401 })
+  const user = await c.data.d1.get(User, c.data.user.id)
+  return Response.json({ user: user || c.data.user })
+}
+
+export async function onRequestPut(c) {
+  return await handleUpdate(c)
+}
+
+export async function onRequestPatch(c) {
+  return await handleUpdate(c)
+}
+
+export async function onRequestPost(c) {
+  return await handleUpdate(c)
+}
+
+async function handleUpdate(c) {
+  if (!c.data.user) throw new APIError('Unauthorized', { status: 401 })
+  const input = await c.request.json()
+  const updates = {}
+  if (input.name !== undefined) updates.name = input.name
+  if (input.image !== undefined) updates.image = input.image
+  if (input.data !== undefined) updates.data = input.data
+
+  const existing = await c.data.d1.get(User, c.data.user.id)
+  if (!existing) {
+    await c.data.d1.insert(User, {
+      id: c.data.user.id,
+      email: c.data.user.email,
+      ...updates,
+    })
+  } else {
+    await c.data.d1.update(User, c.data.user.id, updates)
+  }
+
+  const updated = await c.data.d1.get(User, c.data.user.id)
+  return Response.json({ user: updated })
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "migrations": "github:treeder/migrations#semver:^2",
         "nanoid": "^6.0.1",
         "once": "github:treeder/once#semver:^1",
-        "passkeys": "github:treeder/passkeys#semver:^4",
+        "passkeys": "github:treeder/passkeys#semver:^5",
         "rend": "github:treeder/rend#semver:^1"
       },
       "devDependencies": {
@@ -2598,8 +2598,8 @@
       "license": "MIT"
     },
     "node_modules/passkeys": {
-      "version": "4.1.2",
-      "resolved": "git+ssh://git@github.com/treeder/passkeys.git#30538f6f9114d1e807329ddb0ae102b4c8d840a9",
+      "version": "5.0.1",
+      "resolved": "git+ssh://git@github.com/treeder/passkeys.git#ff65199d8694ee891f8a65753989ffc10801520e",
       "license": "MIT",
       "dependencies": {
         "@simplewebauthn/server": "^13.3.2",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "migrations": "github:treeder/migrations#semver:^2",
     "nanoid": "^6.0.1",
     "once": "github:treeder/once#semver:^1",
-    "passkeys": "github:treeder/passkeys#semver:^4",
+    "passkeys": "github:treeder/passkeys#semver:^5",
     "rend": "github:treeder/rend#semver:^1"
   },
   "devDependencies": {

--- a/public/components/avatar-menu.js
+++ b/public/components/avatar-menu.js
@@ -1,0 +1,155 @@
+import { LitElement, html, css } from 'lit'
+import 'material/menu/menu.js'
+import 'material/menu/menu-item.js'
+import 'material/divider/divider.js'
+import 'material/icon/icon.js'
+import { signOut } from 'passkeys/public/js/signout.js'
+import { styles } from '/css/styles.js'
+
+export class AvatarMenu extends LitElement {
+  static styles = [
+    styles,
+    css`
+      :host {
+        display: inline-block;
+        position: relative;
+      }
+      .avatar-btn {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 38px;
+        height: 38px;
+        border-radius: 50%;
+        border: 2px solid var(--md-sys-color-outline-variant, #ccc);
+        background: var(--md-sys-color-primary-container, #eaddff);
+        color: var(--md-sys-color-on-primary-container, #21005d);
+        cursor: pointer;
+        padding: 0;
+        overflow: hidden;
+        font-weight: 600;
+        font-size: 15px;
+        transition:
+          box-shadow 0.2s,
+          border-color 0.2s,
+          transform 0.1s;
+      }
+      .avatar-btn:hover {
+        box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
+        border-color: var(--md-sys-color-primary, #6750a4);
+      }
+      .avatar-btn:active {
+        transform: scale(0.96);
+      }
+      .avatar-img {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+      }
+      .menu-header {
+        padding: 12px 16px;
+        min-width: 200px;
+        box-sizing: border-box;
+      }
+      .menu-name {
+        font-weight: 600;
+        font-size: 14px;
+        color: var(--md-sys-color-on-surface, #1c1b1f);
+      }
+      .menu-email {
+        font-size: 12px;
+        color: var(--md-sys-color-on-surface-variant, #49454f);
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        margin-top: 2px;
+      }
+      a.menu-link {
+        text-decoration: none;
+        color: inherit;
+        display: block;
+      }
+      md-menu-item {
+        cursor: pointer;
+      }
+    `,
+  ]
+
+  static properties = {
+    user: { type: Object },
+  }
+
+  constructor() {
+    super()
+    this.user = {}
+  }
+
+  getUser() {
+    if (typeof this.user === 'string') {
+      try {
+        return JSON.parse(this.user)
+      } catch (e) {
+        return {}
+      }
+    }
+    return this.user || {}
+  }
+
+  toggleMenu(e) {
+    e?.stopPropagation()
+    const menu = this.renderRoot.querySelector('#avatar-menu')
+    if (menu) {
+      menu.open = !menu.open
+    }
+  }
+
+  async handleSignOut(e) {
+    e?.preventDefault()
+    signOut()
+    window.location.href = '/'
+  }
+
+  render() {
+    const user = this.getUser()
+    const imageUrl = user.image || user.avatarUrl || user.data?.image || user.data?.avatarUrl
+    const initial = (user.name || user.email || 'U').charAt(0).toUpperCase()
+
+    return html`
+      <div style="position: relative; display: inline-block;">
+        <button
+          id="avatar-anchor"
+          class="avatar-btn"
+          @click=${this.toggleMenu}
+          aria-label="User account menu"
+          aria-haspopup="true">
+          ${
+            imageUrl
+              ? html`<img src="${imageUrl}" class="avatar-img" alt="${user.name || 'User Avatar'}" />`
+              : html`<span>${initial}</span>`
+          }
+        </button>
+
+        <md-menu id="avatar-menu" anchor="avatar-anchor" anchor-corner="end-end" menu-corner="start-end">
+          <div class="menu-header">
+            <div class="menu-name">${user.name || 'Account'}</div>
+            <div class="menu-email">${user.email || ''}</div>
+          </div>
+          <md-divider></md-divider>
+          <a href="/settings" class="menu-link">
+            <md-menu-item>
+              <md-icon slot="start">settings</md-icon>
+              <div slot="headline">Settings</div>
+            </md-menu-item>
+          </a>
+          <md-divider></md-divider>
+          <md-menu-item @click=${this.handleSignOut}>
+            <md-icon slot="start">logout</md-icon>
+            <div slot="headline">Sign out</div>
+          </md-menu-item>
+        </md-menu>
+      </div>
+    `
+  }
+}
+
+customElements.define('avatar-menu', AvatarMenu)

--- a/public/components/avatar-menu.js
+++ b/public/components/avatar-menu.js
@@ -84,6 +84,21 @@ export class AvatarMenu extends LitElement {
     this.user = {}
   }
 
+  async connectedCallback() {
+    super.connectedCallback()
+    if (!this.getUser().email) {
+      try {
+        const res = await api('/v1/users/me')
+        if (res?.user) {
+          this.user = {
+            ...this.getUser(),
+            ...res.user,
+          }
+        }
+      } catch (e) {}
+    }
+  }
+
   getUser() {
     if (typeof this.user === 'string') {
       try {

--- a/public/components/settings-page.js
+++ b/public/components/settings-page.js
@@ -1,0 +1,518 @@
+import { LitElement, html, css } from 'lit'
+import 'material/text/text-field.js'
+import 'material/buttons/button.js'
+import 'material/buttons/icon-button.js'
+import 'material/card/card.js'
+import 'material/icon/icon.js'
+import 'material/divider/divider.js'
+import '/components/confirm-dialog.js'
+import { styles } from '/css/styles.js'
+import { api } from 'api'
+import { startRegistration } from 'passkeys/public/js/auth.js'
+
+export class SettingsPage extends LitElement {
+  static styles = [
+    styles,
+    css`
+      :host {
+        display: block;
+        width: 100%;
+        max-width: 680px;
+        margin: 0 auto;
+      }
+      .settings-section {
+        display: flex;
+        flex-direction: column;
+        gap: 16px;
+      }
+      .avatar-wrapper {
+        display: flex;
+        align-items: center;
+        gap: 20px;
+      }
+      .avatar-preview {
+        width: 96px;
+        height: 96px;
+        border-radius: 50%;
+        border: 2px solid var(--md-sys-color-outline-variant, #ccc);
+        background: var(--md-sys-color-primary-container, #eaddff);
+        color: var(--md-sys-color-on-primary-container, #21005d);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 36px;
+        font-weight: 600;
+        overflow: hidden;
+        flex-shrink: 0;
+      }
+      .avatar-preview img {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+      }
+      .passkey-item {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 12px 16px;
+        border-radius: 8px;
+        background: var(--md-sys-color-surface-container, rgba(0, 0, 0, 0.04));
+        border: 1px solid var(--md-sys-color-outline-variant, #e0e0e0);
+      }
+      .passkey-info {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+      }
+      .passkey-icon {
+        width: 40px;
+        height: 40px;
+        border-radius: 50%;
+        background: var(--md-sys-color-primary-container, #eaddff);
+        color: var(--md-sys-color-on-primary-container, #21005d);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        flex-shrink: 0;
+      }
+      .badge {
+        font-size: 11px;
+        padding: 2px 8px;
+        border-radius: 12px;
+        background: var(--md-sys-color-secondary-container, #e8def8);
+        color: var(--md-sys-color-on-secondary-container, #1d192b);
+        font-weight: 500;
+        display: inline-block;
+      }
+      .feedback-msg {
+        padding: 10px 14px;
+        border-radius: 6px;
+        font-size: 13px;
+        font-weight: 500;
+      }
+      .feedback-success {
+        background: #e8f5e9;
+        color: #2e7d32;
+        border: 1px solid #c8e6c9;
+      }
+      .feedback-error {
+        background: #ffebee;
+        color: #c62828;
+        border: 1px solid #ffcdd2;
+      }
+      md-icon-button.error {
+        --md-icon-button-icon-color: var(--error-color, var(--md-sys-color-error, #ba1a1a));
+      }
+    `,
+  ]
+
+  static properties = {
+    user: { type: Object },
+    passkeys: { type: Array },
+    loadingAvatar: { type: Boolean },
+    loadingProfile: { type: Boolean },
+    loadingPasskeys: { type: Boolean },
+    profileMessage: { type: Object },
+    avatarMessage: { type: Object },
+    passkeyMessage: { type: Object },
+  }
+
+  constructor() {
+    super()
+    this.user = {}
+    this.passkeys = []
+    this.loadingAvatar = false
+    this.loadingProfile = false
+    this.loadingPasskeys = false
+    this.profileMessage = null
+    this.avatarMessage = null
+    this.passkeyMessage = null
+  }
+
+  connectedCallback() {
+    super.connectedCallback()
+    this.initUser()
+    this.fetchPasskeys()
+  }
+
+  initUser() {
+    if (typeof this.user === 'string') {
+      try {
+        this.user = JSON.parse(this.user)
+      } catch (e) {
+        this.user = {}
+      }
+    }
+  }
+
+  async fetchPasskeys() {
+    this.loadingPasskeys = true
+    try {
+      const res = await api('/auth/passkeys/list')
+      this.passkeys = res.passkeys || []
+    } catch (e) {
+      console.error('Failed to fetch passkeys', e)
+    } finally {
+      this.loadingPasskeys = false
+    }
+  }
+
+  triggerAvatarUpload() {
+    const input = this.renderRoot.querySelector('#avatar-file-input')
+    if (input) {
+      input.click()
+    }
+  }
+
+  async handleAvatarChange(e) {
+    const file = e.target.files?.[0]
+    if (!file) return
+
+    this.loadingAvatar = true
+    this.avatarMessage = null
+
+    try {
+      const formData = new FormData()
+      formData.append('file', file)
+
+      const res = await fetch('/v1/users/avatar', {
+        method: 'POST',
+        body: formData,
+      })
+
+      const data = await res.json()
+      if (!res.ok) {
+        throw new Error(data.error?.message || data.message || 'Avatar upload failed')
+      }
+
+      this.user = {
+        ...this.user,
+        image: data.image,
+      }
+      this.avatarMessage = { type: 'success', text: 'Avatar updated successfully!' }
+
+      // Update any avatar menu instances on page
+      const avatarMenu = document.querySelector('avatar-menu')
+      if (avatarMenu) {
+        avatarMenu.user = this.user
+        avatarMenu.requestUpdate()
+      }
+    } catch (err) {
+      console.error(err)
+      this.avatarMessage = { type: 'error', text: err.message || 'Failed to upload avatar' }
+    } finally {
+      this.loadingAvatar = false
+      e.target.value = ''
+    }
+  }
+
+  async removeAvatar() {
+    const dialog = this.renderRoot.querySelector('#confirmDialog')
+    const confirmed = await dialog.confirm({
+      headline: 'Remove Avatar',
+      message: 'Are you sure you want to remove your profile photo?',
+      confirmText: 'Remove',
+      destructive: true,
+      icon: 'delete',
+    })
+    if (!confirmed) return
+
+    this.loadingAvatar = true
+    this.avatarMessage = null
+
+    try {
+      const res = await fetch('/v1/users/avatar', {
+        method: 'DELETE',
+      })
+      const data = await res.json()
+      if (!res.ok) {
+        throw new Error(data.error?.message || 'Failed to remove avatar')
+      }
+
+      this.user = {
+        ...this.user,
+        image: null,
+      }
+      this.avatarMessage = { type: 'success', text: 'Avatar removed.' }
+
+      const avatarMenu = document.querySelector('avatar-menu')
+      if (avatarMenu) {
+        avatarMenu.user = this.user
+        avatarMenu.requestUpdate()
+      }
+    } catch (err) {
+      console.error(err)
+      this.avatarMessage = { type: 'error', text: err.message || 'Failed to remove avatar' }
+    } finally {
+      this.loadingAvatar = false
+    }
+  }
+
+  async saveProfile() {
+    const nameField = this.renderRoot.querySelector('#name-field')
+    const name = nameField ? nameField.value.trim() : ''
+
+    this.loadingProfile = true
+    this.profileMessage = null
+
+    try {
+      const res = await api('/v1/users/me', {
+        method: 'POST',
+        body: { name },
+      })
+
+      this.user = {
+        ...this.user,
+        name: res.user?.name || name,
+      }
+      this.profileMessage = { type: 'success', text: 'Profile updated successfully!' }
+
+      const avatarMenu = document.querySelector('avatar-menu')
+      if (avatarMenu) {
+        avatarMenu.user = this.user
+        avatarMenu.requestUpdate()
+      }
+    } catch (err) {
+      console.error(err)
+      this.profileMessage = { type: 'error', text: err.message || 'Failed to update profile' }
+    } finally {
+      this.loadingProfile = false
+    }
+  }
+
+  async addPasskey() {
+    this.passkeyMessage = null
+    try {
+      const regOptions = await api('/auth/passkeys/new', {
+        method: 'POST',
+        body: {},
+      })
+
+      const attResp = await startRegistration({
+        optionsJSON: regOptions,
+      })
+
+      const createRes = await api('/auth/passkeys/create', {
+        method: 'POST',
+        body: {
+          credential: attResp,
+          userId: regOptions.user.id,
+        },
+      })
+
+      if (!createRes.verified) {
+        throw new Error('Passkey verification failed.')
+      }
+
+      this.passkeyMessage = { type: 'success', text: 'Passkey successfully added!' }
+      await this.fetchPasskeys()
+    } catch (err) {
+      console.error(err)
+      if (err.name !== 'AbortError' && !err.message?.includes('cancelled')) {
+        this.passkeyMessage = { type: 'error', text: err.message || 'Failed to register passkey' }
+      }
+    }
+  }
+
+  async deletePasskey(passkeyId) {
+    const dialog = this.renderRoot.querySelector('#confirmDialog')
+    const confirmed = await dialog.confirm({
+      headline: 'Remove Passkey',
+      message: 'Are you sure you want to remove this passkey? You will no longer be able to sign in with it.',
+      confirmText: 'Remove',
+      destructive: true,
+      icon: 'delete',
+    })
+    if (!confirmed) return
+
+    try {
+      await api('/auth/passkeys/delete', {
+        method: 'POST',
+        body: { id: passkeyId },
+      })
+      this.passkeyMessage = { type: 'success', text: 'Passkey removed.' }
+      await this.fetchPasskeys()
+    } catch (err) {
+      console.error(err)
+      this.passkeyMessage = { type: 'error', text: err.message || 'Failed to remove passkey' }
+    }
+  }
+
+  render() {
+    const user = this.user || {}
+    const initial = (user.name || user.email || 'U').charAt(0).toUpperCase()
+    const imageUrl = user.image || user.avatarUrl || user.data?.image
+
+    return html`
+      <confirm-dialog id="confirmDialog"></confirm-dialog>
+
+      <div class="flex col g24 w100">
+        <div class="headline-medium">Account Settings</div>
+
+        <!-- Section 1: Profile & Avatar -->
+        <md-card class="p24 w100" style="box-sizing: border-box;">
+          <div class="settings-section">
+            <div class="title-large">Profile</div>
+            <div class="text-muted small">Manage your public avatar and profile details.</div>
+
+            ${
+              this.avatarMessage
+                ? html`<div class="feedback-msg feedback-${this.avatarMessage.type}">${this.avatarMessage.text}</div>`
+                : ''
+            }
+
+            <div class="avatar-wrapper mt8">
+              <div class="avatar-preview">
+                ${
+                  imageUrl
+                    ? html`<img src="${imageUrl}" alt="${user.name || 'User Avatar'}" />`
+                    : html`<span>${initial}</span>`
+                }
+              </div>
+              <div class="flex col g8">
+                <input
+                  type="file"
+                  id="avatar-file-input"
+                  accept="image/png,image/jpeg,image/webp,image/gif"
+                  style="display: none;"
+                  @change=${this.handleAvatarChange} />
+                <div class="flex g8 flexw">
+                  <md-button type="button" @click=${this.triggerAvatarUpload} ?disabled=${this.loadingAvatar}>
+                    <md-icon slot="icon">cloud_upload</md-icon>
+                    ${this.loadingAvatar ? 'Uploading...' : 'Upload New Photo'}
+                  </md-button>
+                  ${
+                    imageUrl
+                      ? html`
+                          <md-button
+                            type="button"
+                            color="outlined"
+                            class="error"
+                            @click=${this.removeAvatar}
+                            ?disabled=${this.loadingAvatar}>
+                            <md-icon slot="icon">delete</md-icon>
+                            Remove
+                          </md-button>
+                        `
+                      : ''
+                  }
+                </div>
+                <div class="text-muted small">Allowed formats: JPG, PNG, WEBP, GIF. Max size 10MB.</div>
+              </div>
+            </div>
+
+            <md-divider class="mt8 mb8"></md-divider>
+
+            ${
+              this.profileMessage
+                ? html`<div class="feedback-msg feedback-${this.profileMessage.type}">${this.profileMessage.text}</div>`
+                : ''
+            }
+
+            <form
+              id="profile-form"
+              class="flex col g16 w100"
+              @submit=${(e) => {
+                e.preventDefault()
+                this.saveProfile()
+              }}>
+              <md-text-field
+                id="name-field"
+                label="Full Name"
+                value="${user.name || ''}"
+                placeholder="Enter your full name"></md-text-field>
+
+              <md-text-field
+                id="email-field"
+                label="Email"
+                value="${user.email || ''}"
+                disabled
+                supporting-text="Email address cannot be changed"></md-text-field>
+
+              <div class="flex jce mt8">
+                <md-button type="button" @click=${this.saveProfile} ?disabled=${this.loadingProfile}>
+                  ${this.loadingProfile ? 'Saving...' : 'Save Profile'}
+                </md-button>
+              </div>
+            </form>
+          </div>
+        </md-card>
+
+        <!-- Section 2: Passkeys & Security -->
+        <md-card class="p24 w100" style="box-sizing: border-box;">
+          <div class="settings-section">
+            <div class="flex jcsb aic flexw g8">
+              <div>
+                <div class="title-large">Passkeys</div>
+                <div class="text-muted small mt4">
+                  Passkeys provide fast and secure sign-in using biometric authentication or security keys.
+                </div>
+              </div>
+              <md-button type="button" @click=${this.addPasskey}>
+                <md-icon slot="icon">add</md-icon>
+                Add Passkey
+              </md-button>
+            </div>
+
+            ${
+              this.passkeyMessage
+                ? html`<div class="feedback-msg feedback-${this.passkeyMessage.type}">${this.passkeyMessage.text}</div>`
+                : ''
+            }
+
+            <div class="flex col g12 mt8">
+              ${
+                this.loadingPasskeys
+                  ? html`<div class="text-muted p16 text-center">Loading passkeys...</div>`
+                  : this.passkeys.length === 0
+                    ? html`
+                        <div
+                          class="text-muted p16 text-center"
+                          style="background: var(--md-sys-color-surface-container, rgba(0,0,0,0.02)); border-radius: 8px;">
+                          No passkeys configured yet. Add one to sign in seamlessly without entering your email every
+                          time.
+                        </div>
+                      `
+                    : this.passkeys.map(
+                        (pk) => html`
+                          <div class="passkey-item">
+                            <div class="passkey-info">
+                              <div class="passkey-icon">
+                                <md-icon>fingerprint</md-icon>
+                              </div>
+                              <div class="flex col g4">
+                                <div style="font-weight: 500; font-size: 14px;">${pk.name || 'Passkey'}</div>
+                                <div class="flex g8 aic flexw">
+                                  <span class="badge"
+                                    >${pk.deviceType === 'multiDevice' ? 'Synced Passkey' : 'Security Key'}</span
+                                  >
+                                  ${
+                                  pk.createdAt
+                                    ? html`<span class="text-muted small"
+                                        >Added on ${new Date(pk.createdAt).toLocaleDateString()}</span
+                                      >`
+                                    : ''
+                                }
+                                </div>
+                              </div>
+                            </div>
+                            <md-icon-button
+                              class="error"
+                              title="Remove Passkey"
+                              aria-label="Remove Passkey"
+                              @click=${() => this.deletePasskey(pk.id)}>
+                              <md-icon>delete</md-icon>
+                            </md-icon-button>
+                          </div>
+                        `,
+                      )
+              }
+            </div>
+          </div>
+        </md-card>
+      </div>
+    `
+  }
+}
+
+customElements.define('settings-page', SettingsPage)

--- a/public/components/settings-page.js
+++ b/public/components/settings-page.js
@@ -129,10 +129,27 @@ export class SettingsPage extends LitElement {
     this.passkeyMessage = null
   }
 
-  connectedCallback() {
+  async connectedCallback() {
     super.connectedCallback()
     this.initUser()
     this.fetchPasskeys()
+    if (!this.user?.email) {
+      await this.fetchUser()
+    }
+  }
+
+  async fetchUser() {
+    try {
+      const res = await api('/v1/users/me')
+      if (res?.user) {
+        this.user = {
+          ...this.user,
+          ...res.user,
+        }
+      }
+    } catch (e) {
+      console.error('Failed to fetch user profile', e)
+    }
   }
 
   initUser() {

--- a/public/components/settings-page.js
+++ b/public/components/settings-page.js
@@ -373,7 +373,7 @@ export class SettingsPage extends LitElement {
                 <input
                   type="file"
                   id="avatar-file-input"
-                  accept="image/png,image/jpeg,image/webp,image/gif"
+                  accept="image/png,image/jpeg,image/webp,image/avif,image/gif"
                   style="display: none;"
                   @change=${this.handleAvatarChange} />
                 <div class="flex g8 flexw">
@@ -397,7 +397,7 @@ export class SettingsPage extends LitElement {
                       : ''
                   }
                 </div>
-                <div class="text-muted small">Allowed formats: JPG, PNG, WEBP, GIF. Max size 10MB.</div>
+                <div class="text-muted small">Allowed formats: JPG, PNG, WEBP, AVIF, GIF. Max size 10MB.</div>
               </div>
             </div>
 
@@ -487,12 +487,12 @@ export class SettingsPage extends LitElement {
                                     >${pk.deviceType === 'multiDevice' ? 'Synced Passkey' : 'Security Key'}</span
                                   >
                                   ${
-                                  pk.createdAt
-                                    ? html`<span class="text-muted small"
-                                        >Added on ${new Date(pk.createdAt).toLocaleDateString()}</span
-                                      >`
-                                    : ''
-                                }
+                                    pk.createdAt
+                                      ? html`<span class="text-muted small"
+                                          >Added on ${new Date(pk.createdAt).toLocaleDateString()}</span
+                                        >`
+                                      : ''
+                                  }
                                 </div>
                               </div>
                             </div>

--- a/tests/settings.test.js
+++ b/tests/settings.test.js
@@ -84,7 +84,7 @@ test('Settings page and Avatar menu integration tests', async () => {
   expect(uploadRes.status).toBe(200)
   const uploadData = await uploadRes.json()
   expect(uploadData.success).toBe(true)
-  expect(uploadData.image).toMatch(/^\/r2\/users\//)
+  expect(uploadData.image).toMatch(/^\/r2\/users\/[^/]+\/avatar-[^/]+\.png$/)
   expect(uploadData.user.image).toBe(uploadData.image)
 
   // Verify avatar image can be retrieved from R2 endpoint

--- a/tests/settings.test.js
+++ b/tests/settings.test.js
@@ -94,6 +94,28 @@ test('Settings page and Avatar menu integration tests', async () => {
   const r2Buffer = await r2Res.arrayBuffer()
   expect(r2Buffer.byteLength).toBe(samplePng.byteLength)
 
+  // 6b. Upload AVIF avatar image to R2
+  const sampleAvif = new Uint8Array([0x00, 0x00, 0x00, 0x1c, 0x66, 0x74, 0x79, 0x70, 0x61, 0x76, 0x69, 0x66])
+  const avifFormData = new FormData()
+  const avifFile = new File([sampleAvif], 'avatar.avif', { type: 'image/avif' })
+  avifFormData.append('file', avifFile)
+
+  const avifUploadRes = await fetch(`${baseURL}/v1/users/avatar`, {
+    method: 'POST',
+    headers: {
+      Cookie: cookieHeader,
+    },
+    body: avifFormData,
+  })
+  expect(avifUploadRes.status).toBe(200)
+  const avifUploadData = await avifUploadRes.json()
+  expect(avifUploadData.success).toBe(true)
+  expect(avifUploadData.image).toMatch(/^\/r2\/users\/[^/]+\/avatar-[^/]+\.avif$/)
+
+  const avifR2Res = await fetch(`${baseURL}${avifUploadData.image}`)
+  expect(avifR2Res.status).toBe(200)
+  expect(avifR2Res.headers.get('content-type')).toBe('image/avif')
+
   // 7. Passkeys listing and deletion endpoints
   const listPasskeysRes = await fetch(`${baseURL}/auth/passkeys/list`, {
     headers: { Cookie: cookieHeader },

--- a/tests/settings.test.js
+++ b/tests/settings.test.js
@@ -62,6 +62,8 @@ test('Settings page and Avatar menu integration tests', async () => {
   const meData = await meRes.json()
   expect(meData.user.name).toBe('Jane Antigravity')
   expect(meData.user.email).toBe(email)
+  expect(meData.user.id).not.toBe(email)
+  expect(meData.user.id.length).toBeGreaterThanOrEqual(10)
 
   // 6. Upload avatar image to R2 under users/{userId}/...
   const samplePng = new Uint8Array([

--- a/tests/settings.test.js
+++ b/tests/settings.test.js
@@ -126,7 +126,7 @@ test('Settings page and Avatar menu integration tests', async () => {
   const listPasskeysData = await listPasskeysRes.json()
   expect(Array.isArray(listPasskeysData.passkeys)).toBe(true)
 
-  // Test passkey delete endpoint
+  // Test passkey delete endpoint with non-existent ID (should return 404)
   const deletePasskeyRes = await fetch(`${baseURL}/auth/passkeys/delete`, {
     method: 'POST',
     headers: {
@@ -135,7 +135,9 @@ test('Settings page and Avatar menu integration tests', async () => {
     },
     body: JSON.stringify({ id: 'non-existent-pk-id' }),
   })
-  expect(deletePasskeyRes.status).toBe(200)
+  expect(deletePasskeyRes.status).toBe(404)
+  const deletePasskeyData = await deletePasskeyRes.json()
+  expect(deletePasskeyData.error).toBeDefined()
 
   // 8. Remove avatar
   const removeAvatarRes = await fetch(`${baseURL}/v1/users/avatar`, {

--- a/tests/settings.test.js
+++ b/tests/settings.test.js
@@ -1,0 +1,130 @@
+import { test, expect } from 'vitest'
+
+test('Settings page and Avatar menu integration tests', async () => {
+  const baseURL = 'http://localhost:8787'
+
+  // 1. Unauthenticated request to /settings redirects to signin
+  const unauthRes = await fetch(`${baseURL}/settings`, { redirect: 'manual' })
+  expect(unauthRes.status).toBe(302)
+  expect(unauthRes.headers.get('location')).toBe('/signin?redirect=/settings')
+
+  // 2. Authenticate user via email magic link flow
+  const email = `test-${Date.now()}@example.com`
+  const startRes = await fetch(`${baseURL}/auth/email/start`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email }),
+  })
+  expect(startRes.status).toBe(200)
+  const startData = await startRes.json()
+  expect(startData.link).toBeDefined()
+
+  // Follow the verification link to obtain auth session cookies
+  const verifyRes = await fetch(startData.link, { redirect: 'manual' })
+  expect(verifyRes.status).toBe(302)
+
+  const setCookieHeaders = verifyRes.headers.getSetCookie?.() || [verifyRes.headers.get('set-cookie')].filter(Boolean)
+  const cookieHeader = setCookieHeaders.map((c) => c.split(';')[0]).join('; ')
+  expect(cookieHeader).toContain('session=')
+  expect(cookieHeader).toContain('userId=')
+
+  // 3. Authenticated request to /settings returns 200 with settings-page component
+  const settingsRes = await fetch(`${baseURL}/settings`, {
+    headers: { Cookie: cookieHeader },
+  })
+  expect(settingsRes.status).toBe(200)
+  const settingsHtml = await settingsRes.text()
+  expect(settingsHtml).toContain('Settings - Flaregun')
+  expect(settingsHtml).toContain('<settings-page')
+  expect(settingsHtml).toContain('<avatar-menu')
+  expect(settingsHtml).toContain('/components/settings-page.js')
+  expect(settingsHtml).toContain('/components/avatar-menu.js')
+
+  // 4. Update full name (user.name) via /v1/users/me
+  const updateRes = await fetch(`${baseURL}/v1/users/me`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Cookie: cookieHeader,
+    },
+    body: JSON.stringify({ name: 'Jane Antigravity' }),
+  })
+  expect(updateRes.status).toBe(200)
+  const updateData = await updateRes.json()
+  expect(updateData.user).toBeDefined()
+  expect(updateData.user.name).toBe('Jane Antigravity')
+
+  // 5. Get current user profile via /v1/users/me
+  const meRes = await fetch(`${baseURL}/v1/users/me`, {
+    headers: { Cookie: cookieHeader },
+  })
+  expect(meRes.status).toBe(200)
+  const meData = await meRes.json()
+  expect(meData.user.name).toBe('Jane Antigravity')
+  expect(meData.user.email).toBe(email)
+
+  // 6. Upload avatar image to R2 under users/{userId}/...
+  const samplePng = new Uint8Array([
+    0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44, 0x52, 0x00, 0x00, 0x00,
+    0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x06, 0x00, 0x00, 0x00, 0x1f, 0x15, 0xc4, 0x89, 0x00, 0x00, 0x00, 0x0a, 0x49,
+    0x44, 0x41, 0x54, 0x78, 0x9c, 0x63, 0x00, 0x01, 0x00, 0x00, 0x05, 0x00, 0x01, 0x0d, 0x0a, 0x2d, 0xb4, 0x00, 0x00,
+    0x00, 0x00, 0x49, 0x45, 0x4e, 0x44, 0xae, 0x42, 0x60, 0x82,
+  ])
+  const formData = new FormData()
+  const file = new File([samplePng], 'avatar.png', { type: 'image/png' })
+  formData.append('file', file)
+
+  const uploadRes = await fetch(`${baseURL}/v1/users/avatar`, {
+    method: 'POST',
+    headers: {
+      Cookie: cookieHeader,
+    },
+    body: formData,
+  })
+  expect(uploadRes.status).toBe(200)
+  const uploadData = await uploadRes.json()
+  expect(uploadData.success).toBe(true)
+  expect(uploadData.image).toMatch(/^\/r2\/users\//)
+  expect(uploadData.user.image).toBe(uploadData.image)
+
+  // Verify avatar image can be retrieved from R2 endpoint
+  const r2Res = await fetch(`${baseURL}${uploadData.image}`)
+  expect(r2Res.status).toBe(200)
+  expect(r2Res.headers.get('content-type')).toBe('image/png')
+  const r2Buffer = await r2Res.arrayBuffer()
+  expect(r2Buffer.byteLength).toBe(samplePng.byteLength)
+
+  // 7. Passkeys listing and deletion endpoints
+  const listPasskeysRes = await fetch(`${baseURL}/auth/passkeys/list`, {
+    headers: { Cookie: cookieHeader },
+  })
+  expect(listPasskeysRes.status).toBe(200)
+  const listPasskeysData = await listPasskeysRes.json()
+  expect(Array.isArray(listPasskeysData.passkeys)).toBe(true)
+
+  // Test passkey delete endpoint
+  const deletePasskeyRes = await fetch(`${baseURL}/auth/passkeys/delete`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Cookie: cookieHeader,
+    },
+    body: JSON.stringify({ id: 'non-existent-pk-id' }),
+  })
+  expect(deletePasskeyRes.status).toBe(200)
+
+  // 8. Remove avatar
+  const removeAvatarRes = await fetch(`${baseURL}/v1/users/avatar`, {
+    method: 'DELETE',
+    headers: { Cookie: cookieHeader },
+  })
+  expect(removeAvatarRes.status).toBe(200)
+  const removeAvatarData = await removeAvatarRes.json()
+  expect(removeAvatarData.success).toBe(true)
+  expect(removeAvatarData.user.image).toBeNull()
+
+  // 9. Signout endpoint clears cookies and redirects home
+  const signoutRes = await fetch(`${baseURL}/signout`, { redirect: 'manual' })
+  expect(signoutRes.status).toBe(302)
+  expect(signoutRes.headers.get('location')).toBe('/')
+})


### PR DESCRIPTION
### Summary of Changes

- **Avatar Menu in Top Right**: Added `avatar-menu` web component in `functions/layout.js` using Material 3 `md-menu`. Displays user avatar / initial and provides links to Settings (`/settings`) and Sign out.
- **Settings Page**: Added protected `/settings` route and `settings-page` component allowing users to:
  - Upload avatar images to Cloudflare R2 under `users/{userId}/` (saved as `user.image` in D1) and remove custom avatars.
  - Edit and save full name (`user.name`) via `/v1/users/me`.
  - View registered passkeys, register new WebAuthn passkeys, and remove existing passkeys.
- **Passkey Management**: Enhanced `/auth/passkeys/[[catchall]]` with `list`, multi-passkey preservation in KV `users-{userId}`, and `delete` endpoints.
- **Signout Route**: Added server-side cookie clearing and redirect at `/signout`.
- **Tests**: Added comprehensive integration test suite in `tests/settings.test.js`.