### PR TITLE
Add domainLevels logic and pass to Passkeys

### DIFF
--- a/functions/auth/[[catchall]].js
+++ b/functions/auth/[[catchall]].js
@@ -1,5 +1,5 @@
 import { Passkeys } from 'passkeys'
-import { hostURL } from '../utils.js'
+import { hostURL, domainLevels } from '../utils.js'
 import { globals } from '../globals.js'
 import { isoBase64URL } from '@simplewebauthn/server/helpers'
 import { User } from '../data/users.js'
@@ -10,6 +10,7 @@ export async function onRequest(c) {
   let passkeys = new Passkeys({
     appName: 'Flaregun',
     baseURL: `${hostURL(c)}/auth`,
+    domainLevels: domainLevels(c),
     kv: c.env.KV,
     // mailer: globals.mailer, // replace with your own mailer instance with send() function
     logger: c.data.logger,

--- a/functions/utils.js
+++ b/functions/utils.js
@@ -29,5 +29,6 @@ export function hostURL(c) {
 export function domainLevels(c) {
   const host = hostname(c)
   if (!host) return 2
-  return host.endsWith('workers.dev') || host.endsWith('pages.dev') ? 3 : 2
+  return host.endsWith('.workers.dev') || host.endsWith('.pages.dev') ? 3 : 2
 }
+

--- a/functions/utils.js
+++ b/functions/utils.js
@@ -9,7 +9,8 @@ export function hostname(c) {
 
 export function hostURL(c) {
   let h = hostname(c)
-  if (h.includes('localhost')) {
+  if (!h) return ''
+  if (h.includes('localhost') || h.includes('127.0.0.1')) {
     let req = c.request
     let h2 = req.headers.get('x-forwarded-host') || req.headers.get('host')
     let port = ''
@@ -23,4 +24,10 @@ export function hostURL(c) {
   }
   h = 'https://' + h
   return h
+}
+
+export function domainLevels(c) {
+  const host = hostname(c)
+  if (!host) return 2
+  return host.endsWith('workers.dev') || host.endsWith('pages.dev') ? 3 : 2
 }

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -44,6 +44,11 @@ describe('utils', () => {
       expect(domainLevels(c)).toBe(3)
     })
 
+    it('returns 2 for custom domains ending with workers.dev without dot', () => {
+      const c = { request: { headers: new Headers({ host: 'myworkers.dev' }) } }
+      expect(domainLevels(c)).toBe(2)
+    })
+
     it('returns 2 for standard custom domains', () => {
       const c = { request: { headers: new Headers({ host: 'app.example.com' }) } }
       expect(domainLevels(c)).toBe(2)
@@ -60,3 +65,4 @@ describe('utils', () => {
     })
   })
 })
+

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest'
+import { hostname, hostURL, domainLevels } from '../functions/utils.js'
+
+describe('utils', () => {
+  describe('hostname', () => {
+    it('extracts hostname from host header', () => {
+      const c = { request: { headers: new Headers({ host: 'example.com:8787' }) } }
+      expect(hostname(c)).toBe('example.com')
+    })
+
+    it('extracts hostname from x-forwarded-host header if present', () => {
+      const c = {
+        request: {
+          headers: new Headers({
+            host: 'internal.local',
+            'x-forwarded-host': 'myapp.workers.dev',
+          }),
+        },
+      }
+      expect(hostname(c)).toBe('myapp.workers.dev')
+    })
+  })
+
+  describe('hostURL', () => {
+    it('returns http URL with port for localhost', () => {
+      const c = { request: { headers: new Headers({ host: 'localhost:8787' }) } }
+      expect(hostURL(c)).toBe('http://localhost:8787')
+    })
+
+    it('returns https URL for production host', () => {
+      const c = { request: { headers: new Headers({ host: 'example.com' }) } }
+      expect(hostURL(c)).toBe('https://example.com')
+    })
+  })
+
+  describe('domainLevels', () => {
+    it('returns 3 for *.workers.dev', () => {
+      const c = { request: { headers: new Headers({ host: 'my-project.workers.dev' }) } }
+      expect(domainLevels(c)).toBe(3)
+    })
+
+    it('returns 3 for *.pages.dev', () => {
+      const c = { request: { headers: new Headers({ host: 'my-project.pages.dev' }) } }
+      expect(domainLevels(c)).toBe(3)
+    })
+
+    it('returns 2 for standard custom domains', () => {
+      const c = { request: { headers: new Headers({ host: 'app.example.com' }) } }
+      expect(domainLevels(c)).toBe(2)
+    })
+
+    it('returns 2 for apex custom domains', () => {
+      const c = { request: { headers: new Headers({ host: 'example.com' }) } }
+      expect(domainLevels(c)).toBe(2)
+    })
+
+    it('returns 2 for localhost', () => {
+      const c = { request: { headers: new Headers({ host: 'localhost:8787' }) } }
+      expect(domainLevels(c)).toBe(2)
+    })
+  })
+})


### PR DESCRIPTION
### Summary

- Added `domainLevels(c)` to `functions/utils.js` to return `3` for `*.workers.dev` and `*.pages.dev` domains, and `2` for custom domains.
- Passed `domainLevels: domainLevels(c)` into `new Passkeys({ ... })` in `functions/auth/[[catchall]].js`.
- Added unit tests in `tests/utils.test.js`.