### PR TITLE
feat: switch to white card with off-white background

### DIFF
--- a/functions/css/styles.css.js
+++ b/functions/css/styles.css.js
@@ -14,7 +14,7 @@ export async function onRequestGet(c) {
 
 export function root(d) {
   return css`
-    @import url(light.css) (prefers-color-scheme: light);
+    @import url(light.css);
     @import url(dark.css) (prefers-color-scheme: dark);
 
     :root {
@@ -26,6 +26,14 @@ export function root(d) {
 
       background: var(--md-sys-color-background);
       color: var(--md-sys-color-on-background);
+
+      --md-card-container-color: var(--md-sys-color-surface, #ffffff);
+    }
+
+    body {
+      background: var(--md-sys-color-background, #f8f9fa);
+      margin: 0;
+      min-height: 100vh;
     }
 
     .topnav a {
@@ -297,7 +305,15 @@ export function all(d) {
     }
 
     .card {
-      color: var(--md-sys-color-on-primary);
+      background-color: var(--md-card-container-color, var(--md-sys-color-surface, #ffffff));
+      color: var(--md-sys-color-on-surface);
+      border-radius: var(--md-card-container-shape, 12px);
+      border: var(--md-card-outline-width, 1px) solid
+        var(--md-card-outline-color, var(--md-sys-color-outline-variant, #cac4d0));
+    }
+
+    md-card {
+      --md-card-container-color: var(--md-sys-color-surface, #ffffff);
     }
 
     ${typography()}

--- a/public/css/dark.css
+++ b/public/css/dark.css
@@ -20,6 +20,7 @@
   --md-sys-color-on-background: rgb(224 226 232);
   --md-sys-color-surface: rgb(18 18 18);
   --md-sys-color-on-surface: rgb(224 226 232);
+  --md-card-container-color: rgb(18 18 18);
   --md-sys-color-surface-variant: rgb(66 71 78);
   --md-sys-color-on-surface-variant: rgb(194 199 206);
   --md-sys-color-outline: rgb(140 145 152);

--- a/public/css/light.css
+++ b/public/css/light.css
@@ -16,10 +16,11 @@
   --md-sys-color-on-error: rgb(255 255 255);
   --md-sys-color-error-container: rgb(255 218 214);
   --md-sys-color-on-error-container: rgb(147 0 10);
-  --md-sys-color-background: rgb(250 250 250);
+  --md-sys-color-background: #f8f9fa;
   --md-sys-color-on-background: rgb(24 28 32);
-  --md-sys-color-surface: rgb(247 249 255);
+  --md-sys-color-surface: #ffffff;
   --md-sys-color-on-surface: rgb(24 28 32);
+  --md-card-container-color: #ffffff;
   --md-sys-color-surface-variant: rgb(222 227 235);
   --md-sys-color-on-surface-variant: rgb(66 71 78);
   --md-sys-color-outline: rgb(114 120 126);
@@ -42,8 +43,8 @@
   --md-sys-color-tertiary-fixed-dim: rgb(132 210 230);
   --md-sys-color-on-tertiary-fixed-variant: rgb(0 78 92);
   --md-sys-color-surface-dim: rgb(215 218 223);
-  --md-sys-color-surface-bright: rgb(247 249 255);
-  --md-sys-color-surface-container-lowest: rgb(255 255 255);
+  --md-sys-color-surface-bright: #ffffff;
+  --md-sys-color-surface-container-lowest: #ffffff;
   --md-sys-color-surface-container-low: rgb(241 244 249);
   --md-sys-color-surface-container: rgb(235 238 243);
   --md-sys-color-surface-container-high: rgb(230 232 238);

--- a/tests/confirm-dialog.test.js
+++ b/tests/confirm-dialog.test.js
@@ -1,7 +1,8 @@
 import { test, expect } from 'vitest'
+import { baseUrl } from './helper.js'
 
 test('confirm-dialog component is served and structured properly', async () => {
-  const res = await fetch('http://localhost:8787/components/confirm-dialog.js')
+  const res = await fetch(`${baseUrl}/components/confirm-dialog.js`)
   expect(res.status).toBe(200)
   const code = await res.text()
 
@@ -17,7 +18,7 @@ test('confirm-dialog component is served and structured properly', async () => {
 })
 
 test('product-list component uses confirm-dialog for delete confirmation', async () => {
-  const res = await fetch('http://localhost:8787/components/product-list.js')
+  const res = await fetch(`${baseUrl}/components/product-list.js`)
   expect(res.status).toBe(200)
   const code = await res.text()
 
@@ -28,7 +29,7 @@ test('product-list component uses confirm-dialog for delete confirmation', async
 })
 
 test('index page includes confirm-dialog component script', async () => {
-  const res = await fetch('http://localhost:8787/')
+  const res = await fetch(`${baseUrl}/`)
   expect(res.status).toBe(200)
   const html = await res.text()
 

--- a/tests/globalSetup.js
+++ b/tests/globalSetup.js
@@ -4,8 +4,9 @@ import http from 'http'
 let serverProcess
 
 export async function setup() {
-  console.log('🚀 Starting dev server in globalSetup...')
-  serverProcess = spawn('npm', ['run', 'run'], {
+  const port = process.env.PORT || 8787
+  console.log(`🚀 Starting dev server on port ${port} in globalSetup...`)
+  serverProcess = spawn('npm', ['run', 'run', '--', '--port', String(port)], {
     shell: true,
     stdio: 'inherit',
     detached: process.platform !== 'win32',
@@ -25,7 +26,7 @@ export async function setup() {
 
     try {
       await new Promise((resolve, reject) => {
-        const req = http.get('http://localhost:8787/', (res) => {
+        const req = http.get(`http://localhost:${port}/`, (res) => {
           res.resume()
           resolve()
         })

--- a/tests/helper.js
+++ b/tests/helper.js
@@ -1,8 +1,11 @@
 import { API } from 'api'
 import 'dotenv/config'
 
+export const port = process.env.PORT || 8787
+export const baseUrl = `http://localhost:${port}`
+
 export const api = new API({
-  apiURL: 'http://localhost:8787',
+  apiURL: baseUrl,
 })
 
 export const c = {

--- a/tests/settings.test.js
+++ b/tests/settings.test.js
@@ -1,7 +1,8 @@
 import { test, expect } from 'vitest'
+import { baseUrl as defaultBaseURL } from './helper.js'
 
 test('Settings page and Avatar menu integration tests', async () => {
-  const baseURL = 'http://localhost:8787'
+  const baseURL = defaultBaseURL
 
   // 1. Unauthenticated request to /settings redirects to signin
   const unauthRes = await fetch(`${baseURL}/settings`, { redirect: 'manual' })

--- a/tests/test1.test.js
+++ b/tests/test1.test.js
@@ -1,5 +1,5 @@
 import { test, expect } from 'vitest'
-import { c } from './helper.js'
+import { c, baseUrl } from './helper.js'
 
 test('test1', async () => {
   let user = {
@@ -20,7 +20,7 @@ test('test1', async () => {
 })
 
 test('signin page renders centered layout and starter component', async () => {
-  const res = await fetch('http://localhost:8787/signin')
+  const res = await fetch(`${baseUrl}/signin`)
   expect(res.status).toBe(200)
   const html = await res.text()
   expect(html).toContain('Sign In - Flaregun')
@@ -28,9 +28,24 @@ test('signin page renders centered layout and starter component', async () => {
   expect(html).toContain('/components/sign-in.js')
   expect(html).toContain('<sign-in baseURL="/auth" afterLoginHref="/"></sign-in>')
 
-  const compRes = await fetch('http://localhost:8787/components/sign-in.js')
+  const compRes = await fetch(`${baseUrl}/components/sign-in.js`)
   expect(compRes.status).toBe(200)
   const compCode = await compRes.text()
   expect(compCode).toContain("customElements.define('sign-in', SignIn)")
   expect(compCode).toContain('md-card')
+})
+
+test('styles define white card on off-white background', async () => {
+  const cssRes = await fetch(`${baseUrl}/css/styles.css`)
+  expect(cssRes.status).toBe(200)
+  const cssText = await cssRes.text()
+  expect(cssText).toContain('--md-card-container-color')
+  expect(cssText).toContain('md-card')
+
+  const lightRes = await fetch(`${baseUrl}/css/light.css`)
+  expect(lightRes.status).toBe(200)
+  const lightText = await lightRes.text()
+  expect(lightText).toContain('--md-sys-color-background: #f8f9fa')
+  expect(lightText).toContain('--md-sys-color-surface: #ffffff')
+  expect(lightText).toContain('--md-card-container-color: #ffffff')
 })

--- a/tests/test1.test.js
+++ b/tests/test1.test.js
@@ -48,4 +48,9 @@ test('styles define white card on off-white background', async () => {
   expect(lightText).toContain('--md-sys-color-background: #f8f9fa')
   expect(lightText).toContain('--md-sys-color-surface: #ffffff')
   expect(lightText).toContain('--md-card-container-color: #ffffff')
+
+  const darkRes = await fetch(`${baseUrl}/css/dark.css`)
+  expect(darkRes.status).toBe(200)
+  const darkText = await darkRes.text()
+  expect(darkText).toContain('--md-card-container-color: rgb(18 18 18)')
 })


### PR DESCRIPTION
## Summary
- Switch default light theme background to off-white (`#f8f9fa`) and cards/surface to pure white (`#ffffff`).
- Define `--md-card-container-color` on `:root` and `md-card`.
- Import `light.css` as default theme in `styles.css.js` with dark mode preference override.
- Add `body` background style and update `.card` utility class.
- Update test suite with style assertions and dynamic port support.